### PR TITLE
Added Check to Prevent Re-Rendering of Component

### DIFF
--- a/src/mixins/bootstrap-element/index.js
+++ b/src/mixins/bootstrap-element/index.js
@@ -24,6 +24,14 @@ const BootstrapElement = superclass => class extends superclass {
                 return serializeAttrValue(name, this.getAttribute(name));
             },
             set(value) {
+                /*
+                 * This method is called when an observable property is removed
+                 * even if the component has already rendered as a result. The
+                 * call to setAttribute triggers a re-render.
+                 * To prevent this behavior, filter out the unnecessary calls.
+                 */
+                if (!this.getAttribute(name)) return;
+
                 const checkedValue = (typeof value !== 'string') ? JSON.stringify(value) : value;
                 this.setAttribute(name, checkedValue);
             }


### PR DESCRIPTION
## Problem
When an observable property was removed from a component,
the `set` method was called which ultimately called `setAttribute`
on the property with a value of `null` which caused the component
to re-render.

Please let me know if there is an alternate solution which works better for this issue.

## Minimum Test Case
Add

```js
console.log('rendered');
```

to the `ToggleViewHyper` example's `render` method as well as editing the demo `index.html` file's `body` element to read as

```html
<body>
    <h1>Demo</h1>
    <toggle-view-hyper
        class="toggle-view"
        view="table"
        source-url="https://reqres.in/api/users?per_page=4">
    </toggle-view-hyper>
</body>
```

I would then change/remove/add the `view` property and observe the results in the console.